### PR TITLE
change scaling code to take height into account

### DIFF
--- a/src/video/dispmanx/SDL_dispmanxvideo.c
+++ b/src/video/dispmanx/SDL_dispmanxvideo.c
@@ -285,13 +285,17 @@ static void DISPMANX_SurfaceSetup(int width,
 		pthread_mutex_init(&surface->pages[i].page_used_mutex, NULL); 
 	}
 
-	dst_width  = _dispvars->dispmanx_height * aspect;	
-	dst_height = _dispvars->dispmanx_height;
+	dst_width  = _dispvars->dispmanx_height * aspect;
+	dst_height = _dispvars->dispmanx_width / aspect;
 
-	/* If we obtain a scaled image width that is bigger than the physical screen width,
-	* then we keep the physical screen width as our maximun width. */
-	if (dst_width > _dispvars->dispmanx_width) 
-	   dst_width = _dispvars->dispmanx_width;
+	/* Don't scale image larger than the screen */
+	if (dst_width > _dispvars->dispmanx_width) {
+		dst_width = _dispvars->dispmanx_width;
+	}
+
+	if (dst_height > _dispvars->dispmanx_height) {
+		dst_height = _dispvars->dispmanx_height;
+	}
 
 	dst_xpos = (_dispvars->dispmanx_width - dst_width) / 2;
 	dst_ypos = (_dispvars->dispmanx_height - dst_height) / 2;


### PR DESCRIPTION
The previous code would just set the height to whatever screen height was - but this could cause the wrong aspect ratio in the case of a screen in portrait mode etc (image would be stretched). I am going to implement some code for RetroPie so the aspect ratio can be adjusted with an env variable too - for the case where the user need to tweak it do do with destination screen pixel ratio vs source. eg c64 pixels are not square.