### PR TITLE
user configurable aspect ratio

### DIFF
--- a/src/video/dispmanx/SDL_dispmanxvideo.c
+++ b/src/video/dispmanx/SDL_dispmanxvideo.c
@@ -511,15 +511,15 @@ static SDL_Surface *DISPMANX_SetVideoMode(_THIS, SDL_Surface *current, int width
 		DISPMANX_InitDispmanx();	
 		DISPMANX_BlankConsole();
 	}
-	
+
 	bool keep_aspect = !SDL_getenv("SDL_DISPMANX_IGNORE_RATIO");
 	float aspect;
 
 	if (keep_aspect) {
-	   aspect = (float)width / (float)height;
+		aspect = (float)width / (float)height;
 	} else {
-	   /* This is unnecesary but allows us to have a general case SurfaceSetup function. */
-	   aspect = (float)_dispvars->dispmanx_width / (float)_dispvars->dispmanx_height;
+		/* This is unnecesary but allows us to have a general case SurfaceSetup function. */
+		aspect = (float)_dispvars->dispmanx_width / (float)_dispvars->dispmanx_height;
 	}
 
 	Uint32 Rmask = 0;

--- a/src/video/dispmanx/SDL_dispmanxvideo.c
+++ b/src/video/dispmanx/SDL_dispmanxvideo.c
@@ -516,7 +516,14 @@ static SDL_Surface *DISPMANX_SetVideoMode(_THIS, SDL_Surface *current, int width
 	float aspect;
 
 	if (keep_aspect) {
-		aspect = (float)width / (float)height;
+		const char *user_aspect = SDL_getenv("SDL_DISPMANX_RATIO");
+		if (user_aspect != NULL) {
+			aspect = strtof(user_aspect, NULL);
+		}
+		/* only allow sensible aspect ratios */
+		if (aspect < 0.2f || aspect > 6.0f) {
+			aspect = (float)width / (float)height;
+		}
 	} else {
 		/* This is unnecesary but allows us to have a general case SurfaceSetup function. */
 		aspect = (float)_dispvars->dispmanx_width / (float)_dispvars->dispmanx_height;


### PR DESCRIPTION
allow user configurable aspect ratio via SDL_DISPMANX_RATIO - eg allows setting aspect ratio of 1.33 for 4:3 aspect for c64 as the pixels are not square

note cosmetic commit in first commit to fix indentation of code section - some other areas of the file also contain some whitespace errors (space indentation instead of tab)